### PR TITLE
Removed Binance deposit address

### DIFF
--- a/blockedAddresses.json
+++ b/blockedAddresses.json
@@ -8,7 +8,6 @@
   "Abn8wb8j1AJ6yt2YGYfQ7nd6R6eiMxo8Pv",
   "AdaJem5R6vFLiEeg4zhdCK6KSpaWYahTHz",
   "AUwk8JxGVG1ZieuDRtT6kmTcNdnnsVAzw5",
-  "AJzoeKrj7RHMwSrPQDPdv61ciVEYpmhkjk",
   "AGfesDHw63FUjhTrPEeePCKwL1NpKtUbuG",
   "AKERuCMPxvTAFYy2XdqwdhfP22ptQTYvNP",
   "AWN2DkZybgdUAcmQPsTj3XETpoUxgAc8sM",


### PR DESCRIPTION
@deanragnarok You added this address in here originally, though I'm not sure where it came from.  @lerider messaged me to remove it stating that it's a Binance address.  Based upon the [address balances](https://neoscan.io/address/AJzoeKrj7RHMwSrPQDPdv61ciVEYpmhkjk), that's probably accurate.